### PR TITLE
:bug: fix handling of default value in SettingsResetButton component

### DIFF
--- a/src/components/SettingsResetButton.vue
+++ b/src/components/SettingsResetButton.vue
@@ -21,7 +21,7 @@ export default {
   },
   methods: {
     resetToDefault() {
-      let newValue = this.config.default;
+      let newValue = Array.isArray(this.config.default) ? [...this.config.default] : this.config.default;
       this.updateEvent(newValue);
     },
   },


### PR DESCRIPTION
While this worked for most scenarios, it posed a limitation when `this.config.default` was an array. In such cases, assigning the array directly led to potential reference issues, where changes to `newValue` could inadvertently affect the original `this.config.default` array.

To address this, the updated code now checks if `this.config.default` is an array. If it is, we create a shallow copy of the array using the spread syntax `[...this.config.default]`. This ensures that `newValue` is a separate instance, preventing any unintended side-effects on the original array. If `this.config.default` is not an array, the assignment remains as it was, directly using the value of `this.config.default`.