### PR TITLE
:bug: fix prop type for selectedValue in SettingsResetButton

### DIFF
--- a/src/components/SettingsResetButton.vue
+++ b/src/components/SettingsResetButton.vue
@@ -11,7 +11,7 @@ export default {
       required: true,
     },
     selectedValue: {
-      type: [String, Array],
+      type: [String, Array, Number],
       required: true,
     },
     updateEvent: {


### PR DESCRIPTION
Initially, the `selectedValue` prop accepted only String or Array types, which caused a type check failure when a Number was passed by a percentage slider. The updated code now includes Number as an acceptable type for `selectedValue`. This change resolves the Vue warning about the prop type mismatch and ensures the component can handle String, Array, or Number types for `selectedValue`.