### PR TITLE
:bug: initialize local storage with default settings on first visit

### DIFF
--- a/src/components/SettingsParseToComponent.vue
+++ b/src/components/SettingsParseToComponent.vue
@@ -42,9 +42,21 @@ export default {
     };
   },
   created() {
-    this.loadSettings();
-  },
+    const userSettings = localStorage.getItem('userSettings');
+    if (userSettings) {
+      this.loadSettings();
+    } else {
+      this.initializeSettings();
+      location.reload();
+
+    }  },
   methods: {
+    initializeSettings() {
+      Object.keys(this.config.settings).forEach(key => {
+        this.selected[key] = this.config.settings[key].default;
+      });
+      this.saveSettings();
+    },
     getComponentType(type) {
       const componentMap = {
         'select-one': 'SettingsSelectOne',


### PR DESCRIPTION
Fix the issue where the settings were not being loaded from local storage when a user visits the website for the first time. 

Changes include:
- Added a check in the `created()` lifecycle hook in the `SettingsParseToComponent.vue` file to see if the local storage is empty. 
- If local storage is empty, it is now initialized with the default settings from the `config` object. 