### PR TITLE
:rocket: add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '20.11.0'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build
+      run: npm run build


### PR DESCRIPTION
Add a build workflow to check if dependabot's pull request will break the build before merging. This workflow will trigger on pull requests, install the project dependencies using `npm ci`, and then attempt to build the project using `npm run build`. If the build fails, the workflow will also fail, preventing the pull request from being merged until the build passes.